### PR TITLE
Update rc format to rc.1, rc.2

### DIFF
--- a/manager.ts
+++ b/manager.ts
@@ -77,13 +77,13 @@ const releaseVersion = async () => {
     const candidates : string[] = [];
     // 이전 버전이 rc 버전인 경우
     if (lastPrerelease != null) {
-        const prereleaseVersion = parseInt(`${lastPrerelease[0]}`.split("rc")[1])
-        candidates.push(`v${semver.coerce(previousCleanTag)}-rc${prereleaseVersion + 1}`)
+        const prereleaseVersion = parseInt(`${lastPrerelease[0]}`.split("rc.")[1])
+        candidates.push(`v${semver.coerce(previousCleanTag)}-rc.${prereleaseVersion + 1}`)
     // 정식 버전인 경우
     } else {
-        candidates.push(`v${semver.coerce(semver.inc(previousCleanTag, 'patch'))}-rc1`)
-        candidates.push(`v${semver.coerce(semver.inc(previousCleanTag, 'minor'))}-rc1`)
-        candidates.push(`v${semver.coerce(semver.inc(previousCleanTag, 'major'))}-rc1`)
+        candidates.push(`v${semver.coerce(semver.inc(previousCleanTag, 'patch'))}-rc.1`)
+        candidates.push(`v${semver.coerce(semver.inc(previousCleanTag, 'minor'))}-rc.1`)
+        candidates.push(`v${semver.coerce(semver.inc(previousCleanTag, 'major'))}-rc.1`)
     }
     // @ts-ignore
     candidates.push(...[


### PR DESCRIPTION
Update the release candidate tag format to use `rc.1`, `rc.2` instead of `rc1`, `rc2`.

* Modify the `releaseVersion` function in `manager.ts` to generate tags in the `rc.1`, `rc.2` format.
* Adjust the `candidates` array in the `releaseVersion` function to include tags like `vX.Y.Z-rc.1`, `vX.Y.Z-rc.2`.
* Update the `lastPrerelease` logic to handle the new `rc.1`, `rc.2` format.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/korECM/git-tag-manager?shareId=22dedd07-86f6-4a7b-a8d6-7f509e8ef9a6).